### PR TITLE
ci: Staging slot active only during the deployment phase

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -160,6 +160,17 @@ stages:
       - job: deployJava
         steps:
           # deploy reporting-fn
+          - task: AzureCLI@2
+            displayName: Start staging slot [PROD]
+            condition: eq('${{ parameters.ENV }}', 'prod')
+            inputs:
+              azureSubscription: $(AZURE_SUBSCRIPTION)
+              addSpnToEnvironment: true
+              scriptType: 'bash'
+              scriptLocation: 'inlineScript'
+              failOnStandardError: true
+              inlineScript: |
+                az functionapp start --name ${{variables.APP_NAME}}-fn-gpd-batch --resource-group $(RESOURCE_GROUP) --slot staging
           - task: AzureFunctionAppContainer@1
             displayName: Deploy Function App [DEV|UAT]
             condition: in('${{ parameters.ENV }}', 'dev', 'uat')
@@ -213,3 +224,14 @@ stages:
               SourceSlot: staging
               SwapWithProduction: true
               Slot: production
+          - task: AzureCLI@2
+            displayName: Stop staging slot [PROD]
+            condition: eq('${{ parameters.ENV }}', 'prod')
+            inputs:
+              azureSubscription: $(AZURE_SUBSCRIPTION)
+              addSpnToEnvironment: true
+              scriptType: 'bash'
+              scriptLocation: 'inlineScript'
+              failOnStandardError: true
+              inlineScript: |
+                az functionapp stop --name ${{variables.APP_NAME}}-fn-gpd-batch --resource-group $(RESOURCE_GROUP) --slot staging


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- `AzureCLI@2` task was added to start staging slot before PROD deploy;
- `AzureCLI@2` task was added to stop staging slot after PROD swap;

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

- In order to avoid the staging slot function from processing the QueueTrigger concurrently with production slot, it is necessary to disable the staging slot after deploy phase.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.